### PR TITLE
Change severity of multiple render methods from error to warning

### DIFF
--- a/packages/bedrock-diagnoser/src/diagnostics/behavior-pack/block/components/diagnose.ts
+++ b/packages/bedrock-diagnoser/src/diagnostics/behavior-pack/block/components/diagnose.ts
@@ -149,7 +149,7 @@ const component_test: Record<string, ComponentCheck<Internal.BehaviorPack.Block>
       diagnoser.add(
         name,
         'Custom blocks were never intended to support multiple different render_method inside this component',
-        DiagnosticSeverity.error,
+        DiagnosticSeverity.warning,
         'behaviorpack.block.components.multiple_render_methods',
       );
   },


### PR DESCRIPTION
It doesn't stop the block from being registered and the content log considers it a warning rather than an error.