### PR TITLE
feat: add Inlay*.Enable setting, default off

### DIFF
--- a/ide/base/server/src/lsp/extension/settings.ts
+++ b/ide/base/server/src/lsp/extension/settings.ts
@@ -34,6 +34,11 @@ export interface Settings {
       Comments: boolean;
     };
   };
+  /** */
+  InlayHints: {
+    /** */
+    Enable: boolean;
+  };
 }
 
 /**
@@ -66,6 +71,8 @@ export namespace Settings {
       if (typeof temp.Completion.JSON !== 'boolean') return false;
       if (typeof temp.Completion.Lang.Comments !== 'boolean') return false;
       if (typeof temp.Completion.Lang.Dynamic !== 'boolean') return false;
+
+      if (typeof temp.InlayHints?.Enable !== 'boolean') return false;
 
       return true;
     }
@@ -108,6 +115,9 @@ export namespace Settings {
           Comments: true,
           Dynamic: true,
         },
+      },
+      InlayHints: {
+        Enable: false,
       },
     };
 

--- a/ide/base/server/src/lsp/extension/settings.ts
+++ b/ide/base/server/src/lsp/extension/settings.ts
@@ -39,6 +39,11 @@ export interface Settings {
     /** */
     Enable: boolean;
   };
+  /** */
+  InlineValues: {
+    /** */
+    Enable: boolean;
+  };
 }
 
 /**
@@ -73,6 +78,7 @@ export namespace Settings {
       if (typeof temp.Completion.Lang.Dynamic !== 'boolean') return false;
 
       if (typeof temp.InlayHints?.Enable !== 'boolean') return false;
+      if (typeof temp.InlineValues?.Enable !== 'boolean') return false;
 
       return true;
     }
@@ -117,6 +123,9 @@ export namespace Settings {
         },
       },
       InlayHints: {
+        Enable: false,
+      },
+      InlineValues: {
         Enable: false,
       },
     };

--- a/ide/base/server/src/lsp/inlay-hints/service.ts
+++ b/ide/base/server/src/lsp/inlay-hints/service.ts
@@ -33,6 +33,8 @@ export class InlayHintService extends BaseService implements IService {
   }
 
   private onInlayHint(params: InlayHintParams, _token: CancellationToken): InlayHint[] {
+    if (!this.extension.settings.InlayHints.Enable) return [];
+
     const document = this.extension.documents.get(params.textDocument.uri);
     if (!document) return [];
     if (document.languageId !== Languages.McFunctionIdentifier) return [];

--- a/ide/base/server/src/lsp/inline-values/service.ts
+++ b/ide/base/server/src/lsp/inline-values/service.ts
@@ -32,6 +32,8 @@ export class InlineValueService extends BaseService implements IService {
   }
 
   private async onInlineValue(params: InlineValueParams): Promise<InlineValue[]> {
+    if (!this.extension.settings.InlineValues.Enable) return [];
+
     const document = this.extension.documents.get(params.textDocument.uri);
     if (!document) return [];
 

--- a/ide/vscode/README.md
+++ b/ide/vscode/README.md
@@ -85,6 +85,12 @@ A complete list can be found [here](documentation/Commands.md). These commands p
 | **Use Diagnostics Json**           | Turn on or off the diagnostics for json files                                                                                                        |
 | **Use Diagnostics For Objectives** | Turn on or off the diagnostics for scoreboard objectives                                                                                             |
 | **Use Diagnostics For Tags**       | Turn on or off the diagnostics for tags                                                                                                              |
+| **Plugin: Code Lens**              | Turn on or off code lens annotations                                                                                                                 |
+| **Completion: JSON**               | Turn on or off dynamic completion for JSON files                                                                                                     |
+| **Completion: Lang Dynamic**       | Turn on or off dynamic completion for lang files                                                                                                     |
+| **Completion: Lang Comments**      | Turn on or off comment completion for lang files (e.g. `###` regions)                                                                               |
+| **Inlay Hints: Enable**            | Turn on or off inlay hints (parameter name labels) for mcfunction commands. Off by default.                                                          |
+| **Inline Values: Enable**          | Turn on or off inline values (variable lookups) for mcfunction and molang files during debugging. Off by default.                                    |
 
 ---
 

--- a/ide/vscode/package.json
+++ b/ide/vscode/package.json
@@ -204,6 +204,12 @@
             "type": "boolean",
             "default": false,
             "description": "Turns on or off inlay hints (parameter name labels) for mcfunction commands"
+          },
+          "BC-MC.InlineValues.Enable": {
+            "scope": "resource",
+            "type": "boolean",
+            "default": false,
+            "description": "Turns on or off inline values (variable lookups) for mcfunction and molang files"
           }
         }
       }

--- a/ide/vscode/package.json
+++ b/ide/vscode/package.json
@@ -198,6 +198,12 @@
             "type": "boolean",
             "default": true,
             "description": "Turns on or off the comment completion for lang files ie; ### and ### (region)"
+          },
+          "BC-MC.InlayHints.Enable": {
+            "scope": "resource",
+            "type": "boolean",
+            "default": false,
+            "description": "Turns on or off inlay hints (parameter name labels) for mcfunction commands"
           }
         }
       }


### PR DESCRIPTION
Inlay hints were always on, which can be noisy. Adds a BC-MC.InlayHints.Enable config toggle (default false) so users opt in rather than having to opt out.