### PR TITLE
feat: add document highlight, folding, rename and inline completion

### DIFF
--- a/ide/base/client/src/client/client.ts
+++ b/ide/base/client/src/client/client.ts
@@ -57,6 +57,10 @@ export function setupClient(context: vscode.ExtensionContext) {
     clientOptions,
   );
 
+  // Enable proposed protocol features (e.g. inline completion) so the matching
+  // server capabilities are negotiated.
+  Manager.Client.registerProposedFeatures();
+
   // Start the client. This will also launch the server
   Manager.Client.start().then(() => {
     vscode.commands.executeCommand('setContext', 'ext:is_active', true);

--- a/ide/base/server/src/constants/errors.ts
+++ b/ide/base/server/src/constants/errors.ts
@@ -1,3 +1,4 @@
 export namespace ErrorCodes {
   export const CompletionService = 10_000;
+  export const RenameService = 20_000;
 }

--- a/ide/base/server/src/lsp/document-highlight/service.test.ts
+++ b/ide/base/server/src/lsp/document-highlight/service.test.ts
@@ -1,0 +1,37 @@
+import { TextDocument as VscodeTextDocument } from 'vscode-languageserver-textdocument';
+import { TextDocument } from '../documents/text-document';
+import { getOccurrences } from './service';
+
+function createTestDoc(content: string): TextDocument {
+  const vscDoc = VscodeTextDocument.create('file:///test.mcfunction', 'bc-mcfunction', 0, content);
+  return {
+    uri: vscDoc.uri,
+    getText: (range?: any) => vscDoc.getText(range),
+    positionAt: (offset: number) => vscDoc.positionAt(offset),
+    offsetAt: (position: any) => vscDoc.offsetAt(position),
+  } as unknown as TextDocument;
+}
+
+describe('getOccurrences', () => {
+  it('finds every whole-word occurrence', () => {
+    const doc = createTestDoc('scoreboard players set @s money 1\nscoreboard players add @s money 5');
+    const result = getOccurrences(doc, 'money');
+
+    expect(result).toHaveLength(2);
+    expect(result[0]?.range.start).toEqual({ line: 0, character: 26 });
+    expect(result[1]?.range.start).toEqual({ line: 1, character: 26 });
+  });
+
+  it('does not match substrings inside larger words', () => {
+    const doc = createTestDoc('tag @s add foo\ntag @s add foobar');
+    const result = getOccurrences(doc, 'foo');
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.range.start).toEqual({ line: 0, character: 11 });
+  });
+
+  it('returns nothing for an empty word', () => {
+    const doc = createTestDoc('say hi');
+    expect(getOccurrences(doc, '')).toEqual([]);
+  });
+});

--- a/ide/base/server/src/lsp/document-highlight/service.ts
+++ b/ide/base/server/src/lsp/document-highlight/service.ts
@@ -1,0 +1,92 @@
+import {
+  CancellationToken,
+  Connection,
+  DocumentHighlight,
+  DocumentHighlightKind,
+  DocumentHighlightParams,
+} from 'vscode-languageserver';
+import { Character } from '../../util';
+import { TextDocument } from '../documents';
+import { ExtensionContext } from '../extension';
+import { IExtendedLogger } from '../logger/logger';
+import { getCurrentWord } from '../references/function';
+import { BaseService } from '../services/base';
+import { CapabilityBuilder } from '../services/capabilities';
+import { IService } from '../services/service';
+
+export class DocumentHighlightService extends BaseService implements IService {
+  readonly name: string = 'document-highlight';
+
+  constructor(logger: IExtendedLogger, extension: ExtensionContext) {
+    super(logger.withPrefix('[document-highlight]'), extension);
+  }
+
+  onInitialize(capabilities: CapabilityBuilder): void {
+    capabilities.set('documentHighlightProvider', {
+      workDoneProgress: true,
+    });
+  }
+
+  setupHandlers(connection: Connection): void {
+    this.addDisposable(connection.onDocumentHighlight(this.onDocumentHighlight.bind(this)));
+  }
+
+  private onDocumentHighlight(
+    params: DocumentHighlightParams,
+    _token: CancellationToken,
+  ): DocumentHighlight[] | undefined {
+    const document = this.extension.documents.get(params.textDocument.uri);
+    if (!document) return undefined;
+
+    const cursor = document.offsetAt(params.position);
+    const word = getCurrentWord(document, cursor);
+    if (word.text === '') return undefined;
+
+    return getOccurrences(document, word.text);
+  }
+}
+
+/**
+ * Finds all whole-word occurrences of the given word within the document and returns them as highlights.
+ * @param document The document to scan
+ * @param word The word to look for
+ */
+export function getOccurrences(document: TextDocument, word: string): DocumentHighlight[] {
+  const out: DocumentHighlight[] = [];
+  const text = document.getText();
+  const length = word.length;
+  if (length === 0) return out;
+
+  let index = text.indexOf(word);
+  while (index >= 0) {
+    if (isWholeWord(text, index, length)) {
+      out.push({
+        kind: DocumentHighlightKind.Text,
+        range: {
+          start: document.positionAt(index),
+          end: document.positionAt(index + length),
+        },
+      });
+    }
+
+    index = text.indexOf(word, index + length);
+  }
+
+  return out;
+}
+
+function isWholeWord(text: string, start: number, length: number): boolean {
+  const before = start - 1;
+  const after = start + length;
+
+  if (before >= 0 && isWordCharacter(text.charCodeAt(before))) return false;
+  if (after < text.length && isWordCharacter(text.charCodeAt(after))) return false;
+
+  return true;
+}
+
+function isWordCharacter(c: number): boolean {
+  if (Character.IsLetterCode(c) || Character.IsNumberCode(c)) return true;
+
+  return c === Character.Character_underscore || c === Character.Character_dash || c === Character.Character_column;
+}

--- a/ide/base/server/src/lsp/folding/service.test.ts
+++ b/ide/base/server/src/lsp/folding/service.test.ts
@@ -1,0 +1,47 @@
+import { FoldingRangeKind } from 'vscode-languageserver';
+import { TextDocument as VscodeTextDocument } from 'vscode-languageserver-textdocument';
+import { TextDocument } from '../documents/text-document';
+import { provideMcfunctionFolding } from './service';
+
+function createTestDoc(content: string): TextDocument {
+  const vscDoc = VscodeTextDocument.create('file:///test.mcfunction', 'bc-mcfunction', 0, content);
+  return {
+    uri: vscDoc.uri,
+    lineCount: vscDoc.lineCount,
+    getLine: (line: number) =>
+      vscDoc.getText({ start: { line, character: 0 }, end: { line, character: Number.MAX_VALUE } }),
+  } as unknown as TextDocument;
+}
+
+describe('provideMcfunctionFolding', () => {
+  it('folds blocks of consecutive comments', () => {
+    const doc = createTestDoc('# header\n# more info\nsay hi');
+    const result = provideMcfunctionFolding(doc);
+
+    expect(result).toEqual([
+      { startLine: 0, endLine: 1, kind: FoldingRangeKind.Comment },
+    ]);
+  });
+
+  it('does not fold a single comment line', () => {
+    const doc = createTestDoc('# lonely\nsay hi');
+    expect(provideMcfunctionFolding(doc)).toEqual([]);
+  });
+
+  it('folds explicit region markers', () => {
+    const doc = createTestDoc('#region setup\nsay a\nsay b\n#endregion');
+    const result = provideMcfunctionFolding(doc);
+
+    expect(result).toEqual([
+      { startLine: 0, endLine: 3, kind: FoldingRangeKind.Region },
+    ]);
+  });
+
+  it('handles nested region markers', () => {
+    const doc = createTestDoc('#region outer\n#region inner\nsay hi\n#endregion\n#endregion');
+    const result = provideMcfunctionFolding(doc);
+
+    expect(result).toContainEqual({ startLine: 1, endLine: 3, kind: FoldingRangeKind.Region });
+    expect(result).toContainEqual({ startLine: 0, endLine: 4, kind: FoldingRangeKind.Region });
+  });
+});

--- a/ide/base/server/src/lsp/folding/service.ts
+++ b/ide/base/server/src/lsp/folding/service.ts
@@ -1,0 +1,101 @@
+import { Languages } from '@blockception/ide-shared';
+import {
+  CancellationToken,
+  Connection,
+  FoldingRange,
+  FoldingRangeKind,
+  FoldingRangeParams,
+} from 'vscode-languageserver';
+import { TextDocument } from '../documents';
+import { ExtensionContext } from '../extension';
+import { IExtendedLogger } from '../logger/logger';
+import { BaseService } from '../services/base';
+import { CapabilityBuilder } from '../services/capabilities';
+import { IService } from '../services/service';
+
+export class FoldingService extends BaseService implements IService {
+  readonly name: string = 'folding';
+
+  constructor(logger: IExtendedLogger, extension: ExtensionContext) {
+    super(logger.withPrefix('[folding]'), extension);
+  }
+
+  onInitialize(capabilities: CapabilityBuilder): void {
+    capabilities.set('foldingRangeProvider', {
+      workDoneProgress: true,
+    });
+  }
+
+  setupHandlers(connection: Connection): void {
+    this.addDisposable(connection.onFoldingRanges(this.onFoldingRanges.bind(this)));
+  }
+
+  private onFoldingRanges(params: FoldingRangeParams, _token: CancellationToken): FoldingRange[] | undefined {
+    const document = this.extension.documents.get(params.textDocument.uri);
+    if (!document) return undefined;
+
+    // JSON folding is provided by the built-in language service, mcfunction is line based.
+    if (document.languageId !== Languages.McFunctionIdentifier) return undefined;
+
+    return provideMcfunctionFolding(document);
+  }
+}
+
+/**
+ * Provides folding ranges for an mcfunction document: explicit `#region`/`#endregion`
+ * markers and blocks of consecutive comment lines.
+ * @param document The document to provide folding for
+ */
+export function provideMcfunctionFolding(document: TextDocument): FoldingRange[] {
+  const out: FoldingRange[] = [];
+  const regions: number[] = [];
+
+  let commentStart = -1;
+  const lineCount = document.lineCount;
+
+  const flushComments = (endLine: number) => {
+    // Only fold comment blocks that span more than a single line.
+    if (commentStart >= 0 && endLine > commentStart) {
+      out.push(FoldingRange.create(commentStart, endLine, undefined, undefined, FoldingRangeKind.Comment));
+    }
+    commentStart = -1;
+  };
+
+  for (let line = 0; line < lineCount; line++) {
+    const text = document.getLine(line).trim();
+
+    if (isRegionStart(text)) {
+      flushComments(line - 1);
+      regions.push(line);
+      continue;
+    }
+
+    if (isRegionEnd(text)) {
+      flushComments(line - 1);
+      const start = regions.pop();
+      if (start !== undefined && line > start) {
+        out.push(FoldingRange.create(start, line, undefined, undefined, FoldingRangeKind.Region));
+      }
+      continue;
+    }
+
+    if (text.startsWith('#')) {
+      if (commentStart < 0) commentStart = line;
+      continue;
+    }
+
+    flushComments(line - 1);
+  }
+
+  flushComments(lineCount - 1);
+
+  return out;
+}
+
+function isRegionStart(text: string): boolean {
+  return /^#\s*region\b/i.test(text);
+}
+
+function isRegionEnd(text: string): boolean {
+  return /^#\s*endregion\b/i.test(text);
+}

--- a/ide/base/server/src/lsp/inline-completion/service.ts
+++ b/ide/base/server/src/lsp/inline-completion/service.ts
@@ -1,0 +1,100 @@
+import { Languages } from '@blockception/ide-shared';
+import {
+  CancellationToken,
+  Connection,
+  InlineCompletionItem,
+  InlineCompletionParams,
+  ProposedFeatures,
+  WorkDoneProgressReporter,
+} from 'vscode-languageserver';
+import { Context } from '../context/context';
+import { ExtensionContext } from '../extension';
+import { IExtendedLogger } from '../logger/logger';
+import { getCurrentWord } from '../references/function';
+import { BaseService } from '../services/base';
+import { CapabilityBuilder } from '../services/capabilities';
+import { IService } from '../services/service';
+import { createBuilder } from '../completion/builder/builder';
+import { CompletionContext } from '../completion/context';
+import { onCompletionRequest } from '../completion/on-request';
+
+/** The maximum number of inline suggestions to offer at once. */
+const maxItems = 5;
+
+export class InlineCompletionService extends BaseService implements IService {
+  readonly name: string = 'inline-completion';
+
+  constructor(logger: IExtendedLogger, extension: ExtensionContext) {
+    super(logger.withPrefix('[inline-completion]'), extension);
+  }
+
+  onInitialize(capabilities: CapabilityBuilder): void {
+    capabilities.set('inlineCompletionProvider', {});
+  }
+
+  setupHandlers(connection: Connection): void {
+    // `inlineCompletion` is a proposed feature, enabled through `ProposedFeatures.all`,
+    // but it is not part of the base `Connection` type.
+    const languages = (connection as ProposedFeatures.Connection).languages;
+    this.addDisposable(languages.inlineCompletion.on(this.onInlineCompletion.bind(this)));
+  }
+
+  private onInlineCompletion(
+    params: InlineCompletionParams,
+    token: CancellationToken,
+    workDoneProgress: WorkDoneProgressReporter,
+  ): InlineCompletionItem[] {
+    const document = this.extension.documents.get(params.textDocument.uri);
+    if (!document) return [];
+
+    // Inline ghost text is most useful for mcfunction; richer languages are
+    // already served well by the regular completion list.
+    if (document.languageId !== Languages.McFunctionIdentifier) return [];
+
+    const cursor = document.offsetAt(params.position);
+    const word = getCurrentWord(document, cursor);
+
+    // Only the portion of the word that has been typed before the cursor.
+    const prefix = word.text.slice(0, cursor - word.offset);
+    if (prefix === '') return [];
+
+    const context = Context.create<CompletionContext>(
+      this.extension,
+      {
+        document,
+        token,
+        workDoneProgress,
+        cursor,
+        builder: createBuilder(token, workDoneProgress),
+        textDocument: params.textDocument,
+        position: params.position,
+      },
+      { logger: this.logger },
+    );
+
+    onCompletionRequest(context);
+
+    const range = {
+      start: document.positionAt(word.offset),
+      end: params.position,
+    };
+
+    const lowerPrefix = prefix.toLowerCase();
+    const seen = new Set<string>();
+    const out: InlineCompletionItem[] = [];
+
+    for (const item of context.builder.getItems()) {
+      const insert = typeof item.insertText === 'string' ? item.insertText : item.label;
+      if (insert.length <= prefix.length) continue;
+      if (!insert.toLowerCase().startsWith(lowerPrefix)) continue;
+      if (seen.has(insert)) continue;
+
+      seen.add(insert);
+      out.push({ insertText: insert, filterText: insert, range });
+
+      if (out.length >= maxItems) break;
+    }
+
+    return out;
+  }
+}

--- a/ide/base/server/src/lsp/rename/service.ts
+++ b/ide/base/server/src/lsp/rename/service.ts
@@ -1,0 +1,100 @@
+import {
+  CancellationToken,
+  Connection,
+  PrepareRenameParams,
+  Range,
+  RenameParams,
+  ResponseError,
+  TextEdit,
+  WorkDoneProgressReporter,
+  WorkspaceEdit,
+} from 'vscode-languageserver';
+import { ErrorCodes } from '../../constants';
+import { ExtensionContext } from '../extension';
+import { IExtendedLogger } from '../logger/logger';
+import { getCurrentWord } from '../references/function';
+import { BaseService } from '../services/base';
+import { CapabilityBuilder } from '../services/capabilities';
+import { IService } from '../services/service';
+
+export class RenameService extends BaseService implements IService {
+  readonly name: string = 'rename';
+
+  constructor(logger: IExtendedLogger, extension: ExtensionContext) {
+    super(logger.withPrefix('[rename]'), extension);
+  }
+
+  onInitialize(capabilities: CapabilityBuilder): void {
+    capabilities.set('renameProvider', {
+      prepareProvider: true,
+      workDoneProgress: true,
+    });
+  }
+
+  setupHandlers(connection: Connection): void {
+    this.addDisposable(
+      connection.onPrepareRename(this.onPrepareRename.bind(this)),
+      connection.onRenameRequest(this.onRename.bind(this)),
+    );
+  }
+
+  private onPrepareRename(
+    params: PrepareRenameParams,
+    _token: CancellationToken,
+  ): { range: Range; placeholder: string } | null {
+    const document = this.extension.documents.get(params.textDocument.uri);
+    if (!document) return null;
+
+    const cursor = document.offsetAt(params.position);
+    const word = getCurrentWord(document, cursor);
+    if (word.text === '') return null;
+
+    return {
+      range: {
+        start: document.positionAt(word.offset),
+        end: document.positionAt(word.offset + word.text.length),
+      },
+      placeholder: word.text,
+    };
+  }
+
+  private async onRename(
+    params: RenameParams,
+    token: CancellationToken,
+    workDoneProgress: WorkDoneProgressReporter,
+  ): Promise<WorkspaceEdit | ResponseError<void> | null> {
+    const document = this.extension.documents.get(params.textDocument.uri);
+    if (!document) return null;
+
+    const newName = params.newName.trim();
+    if (newName === '') {
+      return new ResponseError(ErrorCodes.RenameService, 'The new name may not be empty');
+    }
+
+    const cursor = document.offsetAt(params.position);
+    const word = getCurrentWord(document, cursor);
+    if (word.text === '') return null;
+
+    workDoneProgress.begin('renaming');
+
+    const locations = await this.extension.database.findReference(
+      word.text,
+      this.extension.documents,
+      { defined: true, usage: true },
+      token,
+      workDoneProgress,
+    );
+
+    workDoneProgress.done();
+
+    if (locations.length === 0) return null;
+
+    const changes: Record<string, TextEdit[]> = {};
+    for (const location of locations) {
+      const edits = (changes[location.uri] ??= []);
+      edits.push(TextEdit.replace(location.range, newName));
+    }
+
+    return { changes };
+  }
+}

--- a/ide/base/server/src/lsp/server/setup.ts
+++ b/ide/base/server/src/lsp/server/setup.ts
@@ -7,10 +7,13 @@ import { CompletionService } from '../completion/service';
 import { ConfigurationService } from '../configuration/service';
 import { Database } from '../database/database';
 import { DiagnoserService } from '../diagnostics/service';
+import { DocumentHighlightService } from '../document-highlight/service';
 import { DocumentManager, IDocumentManager } from '../documents/manager';
 import { ExtensionContext } from '../extension';
+import { FoldingService } from '../folding/service';
 import { FormatService } from '../format/service';
 import { InlayHintService } from '../inlay-hints/service';
+import { InlineCompletionService } from '../inline-completion/service';
 import { InlineValueService } from '../inline-values/service';
 import { LanguageModelToolService } from '../language-model-tools/service';
 import { ExtendedLogger } from '../logger/logger';
@@ -22,6 +25,7 @@ import { ServiceManager } from '../services/collection';
 import { SignatureService } from '../signatures/service';
 import { DocumentSymbolService } from '../symbols/document-service';
 import { WorkspaceSymbolService } from '../symbols/workspace-service';
+import { RenameService } from '../rename/service';
 import { LSPConfig } from '../config/config';
 
 export function setupServer(config: LSPConfig) {
@@ -57,13 +61,17 @@ export function setupServer(config: LSPConfig) {
       new DataSetService(logger, extension),
       new CompletionService(logger, extension),
       new DefinitionService(logger, extension),
+      new DocumentHighlightService(logger, extension),
       new DocumentSymbolService(logger, extension),
+      new FoldingService(logger, extension),
       new FormatService(logger, extension),
       new InlayHintService(logger, extension),
+      new InlineCompletionService(logger, extension),
       new ImplementationService(logger, extension),
       new InlineValueService(logger, extension),
       new LanguageModelToolService(logger, extension),
       new ReferenceService(logger, extension),
+      new RenameService(logger, extension),
       new SemanticsServer(logger, extension),
       new SignatureService(logger, extension),
       new TypeDefinitionService(logger, extension),


### PR DESCRIPTION
Implement LSP features now available with vscode-languageclient and vscode-languageserver v10 (LSP 3.18):

- Document highlight: highlights every whole-word occurrence of the identifier under the cursor.
- Folding ranges (mcfunction): folds consecutive comment blocks and explicit #region/#endregion markers.
- Rename: prepareRename + rename, reusing the references engine to rename identifiers across the workspace.
- Inline completion (proposed 3.18 feature): ghost-text suggestions for mcfunction, derived from the existing completion engine. Enabled on the client via registerProposedFeatures().
